### PR TITLE
More macOS compatibility fixes

### DIFF
--- a/pngpriv.h
+++ b/pngpriv.h
@@ -439,18 +439,7 @@
     */
 #  include <float.h>
 
-#  if (defined(__MWERKS__) && defined(macintosh)) || defined(applec) || \
-    defined(THINK_C) || defined(__SC__) || defined(TARGET_OS_MAC)
-     /* We need to check that <math.h> hasn't already been included earlier
-      * as it seems it doesn't agree with <fp.h>, yet we should really use
-      * <fp.h> if possible.
-      */
-#    if !defined(__MATH_H__) && !defined(__MATH_H) && !defined(__cmath__)
-#      include <fp.h>
-#    endif
-#  else
-#    include <math.h>
-#  endif
+#  include <math.h>
 #  if defined(_AMIGA) && defined(__SASC) && defined(_M68881)
      /* Amiga SAS/C: We must include builtin FPU functions when compiling using
       * MATH=68881


### PR DESCRIPTION
This cherrypicks pnggroup/libpng@893b8113f04d408cc6177c6de19c9889a48faa24 which is a source of another macOS compatibility breakage on the latest versions of the macOS developer tools (Xcode 16.4 for me, but was probably introduced in 16), possibly also combined with the latest LLVM target conditional changes. (See commit body for more info.)

Progress towards resolving crawl/crawl#4520.